### PR TITLE
Fix invalid cross-device link error message (alternative to #20)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - '*'
       - '!master'
+  workflow_dispatch: {}
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
See #20 reported by @steinbrueckri 
> I am currently writing a helmet chart for gcppromd to achieve this I wanted to work with a PVC that I then mount back into the Prometheus pure and then the targets can scrape.

> I noticed that when I configure gcppromd to put the target file on a PVC, an error message is thrown.

> {"error": "rename /tmp/577924968 /data/targets.json: invalid cross-device link", "file":"/data/targets.json", "level": "error", "msg": "could not write output file", "time": "2021-06-10T12:23:29Z"}

This PR make gcppromd create the temporary file in the same directory as the target output file in the daemon mode to avoid cross volumes copy or move. 
